### PR TITLE
Release 1.4

### DIFF
--- a/block-template-parts/entry-comments.html
+++ b/block-template-parts/entry-comments.html
@@ -1,3 +1,0 @@
-<!-- wp:post-comments /-->
-
-<!-- wp:post-comments-form /-->

--- a/block-template-parts/entry-footer.html
+++ b/block-template-parts/entry-footer.html
@@ -1,6 +1,2 @@
 <!-- wp:group {"className":"entry-footer"} -->
-<div class="wp-block-group entry-footer"><div class="wp-block-group__inner-container">
-  <!-- wp:paragraph --><p>Posted on</p> <!-- /wp:paragraph --><!-- wp:post-date /-->
-  <!-- wp:post-author {"showAvatar":false,"byline":"By"} /-->
-</div></div>
-<!-- /wp:group -->
+<div class="wp-block-group entry-footer"><!-- wp:paragraph --><p>Posted on</p> <!-- /wp:paragraph --><!-- wp:post-date /--><!-- wp:post-author {"showAvatar":false,"byline":"By"} /--></div><!-- /wp:group -->

--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,3 +1,3 @@
 <!-- wp:group -->
-<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:paragraph --><p><a href="http://wordpress.org/" rel="nofollow">Proudly powered by WordPress</a> • Theme: <a href="https://wordpress.org/themes/block-based-bosco/" rel="nofollow">Block-Based Bosco</a></p><!-- /wp:paragraph --></div></div>
+<div class="wp-block-group"><!-- wp:paragraph --><p><a href="http://wordpress.org/" rel="nofollow">Proudly powered by WordPress</a> • Theme: <a href="https://wordpress.org/themes/block-based-bosco/" rel="nofollow">Block-Based Bosco</a></p><!-- /wp:paragraph --></div>
 <!-- /wp:group -->

--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,3 +1,3 @@
 <!-- wp:group -->
-<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:paragraph --><p><a href="http://wordpress.org/" rel="nofollow">Proudly powered by WordPress</a> • Theme: Bosco by <a href="https://wpdevelopment.courses" rel="nofollow">WP Development Courses</a>.</p><!-- /wp:paragraph --></div></div>
+<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:paragraph --><p><a href="http://wordpress.org/" rel="nofollow">Proudly powered by WordPress</a> • Theme: <a href="https://wordpress.org/themes/block-based-bosco/" rel="nofollow">Block-Based Bosco</a></p><!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -6,17 +6,13 @@
   <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"list","contentSize":"750px"}} -->
   <div class="wp-block-query"><!-- wp:post-template -->
     <!-- wp:group {"className":"entry"} -->
-    <div class="wp-block-group entry"><!-- wp:group {"className":"entry-header"} -->
-      <div class="wp-block-group entry-header"><!-- wp:post-title {"textAlign":"center","isLink":true} /--></div>
-      <!-- /wp:group -->
+    <div class="wp-block-group entry"><!-- wp:post-title {"textAlign":"center","isLink":true} /-->
 
-      <!-- wp:group {"className":"entry-featured-image"} -->
-      <div class="wp-block-group entry-featured-image"><!-- wp:post-featured-image /--></div>
-      <!-- /wp:group -->
+      <!-- wp:post-featured-image /-->
 
-      <!-- wp:post-content /-->
+      <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-      <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /--></div>
+      <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco","layout":{"inherit":true}} /--></div>
     <!-- /wp:group -->
     <!-- /wp:post-template -->
 

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -3,35 +3,33 @@
 
   <!-- wp:navigation {"orientation":"horizontal"} /-->
 
-  <!-- wp:group {"className":"site-content"} -->
-  <div class="wp-block-group site-content"><!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"list"}} -->
-    <div class="wp-block-query"><!-- wp:post-template -->
-      <!-- wp:group {"className":"entry"} -->
-      <div class="wp-block-group entry"><!-- wp:group {"className":"entry-header"} -->
-        <div class="wp-block-group entry-header"><!-- wp:post-title {"textAlign":"center","isLink":true} /--></div>
-        <!-- /wp:group -->
-
-        <!-- wp:group {"className":"entry-featured-image"} -->
-        <div class="wp-block-group entry-featured-image"><!-- wp:post-featured-image /--></div>
-        <!-- /wp:group -->
-
-        <!-- wp:post-content /-->
-
-        <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /--></div>
+  <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"list","contentSize":"750px"}} -->
+  <div class="wp-block-query"><!-- wp:post-template -->
+    <!-- wp:group {"className":"entry"} -->
+    <div class="wp-block-group entry"><!-- wp:group {"className":"entry-header"} -->
+      <div class="wp-block-group entry-header"><!-- wp:post-title {"textAlign":"center","isLink":true} /--></div>
       <!-- /wp:group -->
-      <!-- /wp:post-template -->
 
-      <!-- wp:group {"className":"posts-navigation"} -->
-      <div class="wp-block-group posts-navigation"><!-- wp:query-pagination -->
-        <div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+      <!-- wp:group {"className":"entry-featured-image"} -->
+      <div class="wp-block-group entry-featured-image"><!-- wp:post-featured-image /--></div>
+      <!-- /wp:group -->
 
-          <!-- wp:query-pagination-numbers /-->
+      <!-- wp:post-content /-->
 
-          <!-- wp:query-pagination-next /--></div>
-        <!-- /wp:query-pagination --></div>
-      <!-- /wp:group --></div>
-    <!-- /wp:query -->
+      <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /--></div>
+    <!-- /wp:group -->
+    <!-- /wp:post-template -->
+
+    <!-- wp:group {"className":"posts-navigation"} -->
+    <div class="wp-block-group posts-navigation"><!-- wp:query-pagination -->
+      <div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+
+        <!-- wp:query-pagination-numbers /-->
+
+        <!-- wp:query-pagination-next /--></div>
+      <!-- /wp:query-pagination --></div>
+    <!-- /wp:group -->
 
     <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div>
-  <!-- /wp:group --></div>
+  <!-- /wp:query --></div>
 <!-- /wp:group -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"className":"site"} -->
+<!-- wp:group {"layout":{"contentSize":"840px"}} -->
 <div class="wp-block-group site"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","tagName":"header","className":"site-header"} /-->
 
   <!-- wp:navigation {"orientation":"horizontal"} /-->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -19,9 +19,6 @@
     <!-- wp:group {"className":"posts-navigation"} -->
     <div class="wp-block-group posts-navigation"><!-- wp:query-pagination -->
       <div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
-
-        <!-- wp:query-pagination-numbers /-->
-
         <!-- wp:query-pagination-next /--></div>
       <!-- /wp:query-pagination --></div>
     <!-- /wp:group -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -1,39 +1,37 @@
 <!-- wp:group {"className":"site"} -->
-<div class="wp-block-group site"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","tagName":"header","className":"site-header"} /-->
+<div class="wp-block-group site"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","tagName":"header","className":"site-header"} /-->
 
   <!-- wp:navigation {"orientation":"horizontal"} /-->
 
   <!-- wp:group {"className":"site-content"} -->
-  <div class="wp-block-group site-content"><div class="wp-block-group__inner-container"><!-- wp:query {"inherit":true} --><!-- wp:post-template -->
-    <!-- wp:group {"className":"entry"} -->
-    <div class="wp-block-group entry"><div class="wp-block-group__inner-container">
-      <!-- wp:group {"className":"entry-header"} -->
-      <div class="wp-block-group entry-header"><div class="wp-block-group__inner-container">
-        <!-- wp:post-title {"textAlign":"center","isLink":true,"linkTarget":"_self"} /-->
-      </div></div>
+  <div class="wp-block-group site-content"><!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"list"}} -->
+    <div class="wp-block-query"><!-- wp:post-template -->
+      <!-- wp:group {"className":"entry"} -->
+      <div class="wp-block-group entry"><!-- wp:group {"className":"entry-header"} -->
+        <div class="wp-block-group entry-header"><!-- wp:post-title {"textAlign":"center","isLink":true} /--></div>
+        <!-- /wp:group -->
+
+        <!-- wp:group {"className":"entry-featured-image"} -->
+        <div class="wp-block-group entry-featured-image"><!-- wp:post-featured-image /--></div>
+        <!-- /wp:group -->
+
+        <!-- wp:post-content /-->
+
+        <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /--></div>
       <!-- /wp:group -->
+      <!-- /wp:post-template -->
 
-      <!-- wp:group {"className":"entry-featured-image"} -->
-      <div class="wp-block-group entry-featured-image"><div class="wp-block-group__inner-container">
-        <!-- wp:post-featured-image {"textAlign":"center"} /-->
-      </div></div>
-      <!-- /wp:group -->
+      <!-- wp:group {"className":"posts-navigation"} -->
+      <div class="wp-block-group posts-navigation"><!-- wp:query-pagination -->
+        <div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
 
-      <!-- wp:post-content /-->
+          <!-- wp:query-pagination-numbers /-->
 
-      <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /-->
-    </div></div>
-    <!-- /wp:group -->
-    <!-- /wp:post-template -->
-
-    <!-- wp:group {"className":"posts-navigation"} -->
-    <div class="wp-block-group posts-navigation"><div class="wp-block-group__inner-container">
-      <!-- wp:query-pagination /-->
-    </div></div>
-    <!-- /wp:group -->
-
+          <!-- wp:query-pagination-next /--></div>
+        <!-- /wp:query-pagination --></div>
+      <!-- /wp:group --></div>
     <!-- /wp:query -->
 
-    <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div></div>
-  <!-- /wp:group --></div></div>
+    <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div>
+  <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -4,7 +4,7 @@
   <!-- wp:navigation {"orientation":"horizontal"} /-->
 
   <!-- wp:group {"className":"site-content"} -->
-  <div class="wp-block-group site-content"><div class="wp-block-group__inner-container"><!-- wp:query {"inherit":true} --><!-- wp:query-loop -->
+  <div class="wp-block-group site-content"><div class="wp-block-group__inner-container"><!-- wp:query {"inherit":true} --><!-- wp:post-template -->
     <!-- wp:group {"className":"entry"} -->
     <div class="wp-block-group entry"><div class="wp-block-group__inner-container">
       <!-- wp:group {"className":"entry-header"} -->
@@ -24,7 +24,7 @@
       <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /-->
     </div></div>
     <!-- /wp:group -->
-    <!-- /wp:query-loop -->
+    <!-- /wp:post-template -->
 
     <!-- wp:group {"className":"posts-navigation"} -->
     <div class="wp-block-group posts-navigation"><div class="wp-block-group__inner-container">

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -1,23 +1,17 @@
-<!-- wp:group {"className":"site"} -->
-<div class="wp-block-group site"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","className":"site-header"} /-->
+<!-- wp:group {"layout":{"contentSize":"840px"}} -->
+<div class="wp-block-group site"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","tagName":"header","className":"site-header"} /-->
 
   <!-- wp:navigation {"orientation":"horizontal"} /-->
 
-  <!-- wp:group {"className":"site-content"} -->
-  <div class="wp-block-group site-content"><div class="wp-block-group__inner-container"><!-- wp:group {"className":"entry"} -->
-    <div class="wp-block-group entry"><div class="wp-block-group__inner-container"><!-- wp:group {"className":"entry-header"} -->
-      <div class="wp-block-group entry-header"><div class="wp-block-group__inner-container"><!-- wp:post-title {"textAlign":"center"} /--></div></div>
-      <!-- /wp:group -->
+  <!-- wp:group {"className":"entry"} -->
+  <div class="wp-block-group entry"><!-- wp:post-title {"textAlign":"center"} /-->
 
-      <!-- wp:group {"className":"entry-featured-image"} -->
-      <div class="wp-block-group entry-featured-image"><div class="wp-block-group__inner-container"><!-- wp:post-featured-image {"textAlign":"center"} /--></div></div>
-      <!-- /wp:group -->
+    <!-- wp:post-featured-image /-->
 
-      <!-- wp:post-content /-->
+    <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-      <!-- wp:post-comments /-->
+    <!-- wp:post-comments /-->
+  </div><!-- /wp:group -->
 
-      <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div></div>
-    <!-- /wp:group --></div></div>
-  <!-- /wp:group --></div></div>
+  <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div>
 <!-- /wp:group -->

--- a/block-templates/page.html
+++ b/block-templates/page.html
@@ -15,7 +15,7 @@
 
       <!-- wp:post-content /-->
 
-      <!-- wp:template-part {"slug":"entry-comments","theme":"block-based-bosco"} /-->
+      <!-- wp:post-comments /-->
 
       <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div></div>
     <!-- /wp:group --></div></div>

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -17,7 +17,7 @@
 
       <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /-->
 
-      <!-- wp:template-part {"slug":"entry-comments","theme":"block-based-bosco"} /-->
+      <!-- wp:post-comments /-->
 
       <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div></div>
     <!-- /wp:group --></div></div>

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -1,25 +1,19 @@
-<!-- wp:group {"className":"site"} -->
-<div class="wp-block-group site"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","className":"site-header"} /-->
+<!-- wp:group {"layout":{"contentSize":"840px"}} -->
+<div class="wp-block-group site"><!-- wp:template-part {"slug":"header","theme":"block-based-bosco","tagName":"header","className":"site-header"} /-->
 
   <!-- wp:navigation {"orientation":"horizontal"} /-->
 
-  <!-- wp:group {"className":"site-content"} -->
-  <div class="wp-block-group site-content"><div class="wp-block-group__inner-container"><!-- wp:group {"className":"entry"} -->
-    <div class="wp-block-group entry"><div class="wp-block-group__inner-container"><!-- wp:group {"className":"entry-header"} -->
-      <div class="wp-block-group entry-header"><div class="wp-block-group__inner-container"><!-- wp:post-title {"textAlign":"center"} /--></div></div>
-      <!-- /wp:group -->
+    <!-- wp:group {"className":"entry"} -->
+    <div class="wp-block-group entry"><!-- wp:post-title {"textAlign":"center","isLink":true} /-->
 
-      <!-- wp:group {"className":"entry-featured-image"} -->
-      <div class="wp-block-group entry-featured-image"><div class="wp-block-group__inner-container"><!-- wp:post-featured-image {"textAlign":"center"} /--></div></div>
-      <!-- /wp:group -->
+      <!-- wp:post-featured-image /-->
 
-      <!-- wp:post-content /-->
+      <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-      <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco"} /-->
+      <!-- wp:template-part {"slug":"entry-footer","theme":"block-based-bosco","layout":{"inherit":true}} /-->
 
       <!-- wp:post-comments /-->
+    </div><!-- /wp:group -->
 
-      <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div></div>
-    <!-- /wp:group --></div></div>
-  <!-- /wp:group --></div></div>
+    <!-- wp:template-part {"slug":"footer","theme":"block-based-bosco","className":"site-footer"} /--></div>
 <!-- /wp:group -->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -4,7 +4,7 @@
   <!-- wp:navigation {"orientation":"horizontal"} /-->
 
     <!-- wp:group {"className":"entry"} -->
-    <div class="wp-block-group entry"><!-- wp:post-title {"textAlign":"center","isLink":true} /-->
+    <div class="wp-block-group entry"><!-- wp:post-title {"textAlign":"center"} /-->
 
       <!-- wp:post-featured-image /-->
 

--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -1,0 +1,10 @@
+/**
+ * Backend styles.
+ */
+
+/* = Entry footer. === */
+
+/* Put a spacer between the "Posted on" text, and the post date. The space in the template part is not respected .*/
+.entry-footer .wp-block-post-date {
+	margin-left: .3125rem !important;
+}

--- a/css/shared.css
+++ b/css/shared.css
@@ -77,4 +77,13 @@
 	margin-left: .3125rem !important;
 }
 
+/* = Blocks == */
 
+.wp-block-post-title a {
+	color: var(--wp--preset--color--black);
+	text-decoration: none;
+}
+
+.wp-block-post-title  a:hover {
+	color: var(--wp--preset--color--red);
+}

--- a/css/shared.css
+++ b/css/shared.css
@@ -128,12 +128,16 @@
 
 /* = Blocks == */
 
+.wp-block-site-title a {
+	text-decoration: none;
+}
+
 .wp-block-post-title a {
 	color: var(--wp--preset--color--black);
 	text-decoration: none;
 }
 
-.wp-block-post-title  a:hover {
+.wp-block-post-title a:hover {
 	color: var(--wp--preset--color--red);
 }
 

--- a/css/shared.css
+++ b/css/shared.css
@@ -1,0 +1,41 @@
+/**
+ * Shared styles between the frontend and the backend.
+ */
+
+/* = Entry footer. === */
+
+/* The "Posted on" text is in a paragraph. This is all we got as Gutenberg doesn't offer <span> tags. */
+.entry-footer > p {
+	display: inline;
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+/* All the blocks in the entry footer should be on the same line. */
+.entry-footer .wp-block-post-author,
+.entry-footer .wp-block-post-author__byline,
+.entry-footer .wp-block-post-author__content,
+.entry-footer .wp-block-post-author__name,
+.entry-footer .wp-block-post-date {
+	display: inline;
+}
+
+/* The post author byline and name are wrapped in paragraph tags, but the design wants them on a single line. */
+.entry-footer .wp-block-post-author__byline {
+	font-size: inherit;
+}
+
+/* Add the dot separator before the post author. */
+.entry-footer .wp-block-post-author__content::before {
+	content: " \2022\ ";
+	margin-left: .5rem;
+	margin-right: .5rem;
+}
+
+.entry-footer .wp-block-post-author__name {
+	font-weight: inherit;
+	/* Override the default Core block style to put a spacer between the By" text, and the post author */
+	margin-left: .3125rem !important;
+}
+
+

--- a/css/shared.css
+++ b/css/shared.css
@@ -2,7 +2,39 @@
  * Shared styles between the frontend and the backend.
  */
 
-/* = Entry footer. === */
+/* = Template parts == */
+
+.site-header {
+	border-bottom: 1px solid var(--wp--preset--color--light-grey);
+	border-top: 5px solid var(--wp--preset--color--red);
+	padding: 2.618em 0;
+}
+
+.site-footer {
+	border-bottom: 5px solid var(--wp--preset--color--red);
+	border-top: 1px solid var(--wp--preset--color--light-grey);
+	color: var(--wp--preset--color--dark-grey);
+	margin-top: 3.75rem;
+	padding: 1.159rem 1.618rem;
+}
+
+.site-footer p {
+	margin: 0;
+}
+
+/* = Entries === */
+
+/* The wrapper for all posts and pages */
+.entry {
+	margin-top: 7.6875rem;
+}
+
+.entry-footer {
+	border-top: 1px solid var(--wp--preset--color--light-grey);
+	color: var(--wp--preset--color--dark-grey);
+	margin-top: 1.811rem;
+	padding-top: 1.12rem;
+}
 
 /* The "Posted on" text is in a paragraph. This is all we got as Gutenberg doesn't offer <span> tags. */
 .entry-footer > p {

--- a/css/shared.css
+++ b/css/shared.css
@@ -22,6 +22,55 @@
 	margin: 0;
 }
 
+/* == Navigation === */
+
+/* By default the navigation template part has a top and bottom border. */
+.wp-block-navigation {
+	border-top: 1px solid var(--wp--preset--color--light-grey);
+	border-bottom: 1px solid var(--wp--preset--color--light-grey);
+}
+
+/* If the navigation template part comes immediately after the header, we do not need the top border. */
+.site-header + .wp-block-navigation {
+	border-top: 0;
+}
+
+/* All links */
+.wp-block-navigation.wp-block-navigation a {
+	color: var(--wp--preset--color--black);
+	font-weight: bold;
+	padding: 1.159rem 1.618rem !important;
+	text-decoration: none;
+	word-wrap: break-word;
+}
+
+.wp-block-navigation-link__content:hover {
+	color: var(--wp--preset--color--red);
+}
+
+/* First level */
+.wp-block-navigation__container > .wp-block-navigation-link {
+	margin: 0 0.89rem;
+}
+
+.wp-block-navigation__container > .wp-block-navigation-link > .wp-block-navigation-link__content {
+	text-transform: uppercase;
+}
+
+.wp-block-navigation-link__submenu-icon {
+	color: var(--wp--preset--color--light-grey);
+}
+
+/* Second level and more */
+.has-child .wp-block-navigation-link__container .wp-block-navigation-link {
+	margin: 0;
+	border-top: 1px solid var(--wp--preset--color--light-grey);
+}
+
+.has-child .wp-block-navigation-link__container .wp-block-navigation-link:first-child {
+	border: none;
+}
+
 /* = Entries === */
 
 /* The wrapper for all posts and pages */

--- a/css/shared.css
+++ b/css/shared.css
@@ -29,6 +29,13 @@
 	margin-top: 7.6875rem;
 }
 
+/* Fix aligned images from breaking out of the container */
+.block-editor-block-list__layout .wp-block,
+.wp-block-post-content {
+	clear: both;
+	overflow: hidden;
+}
+
 .entry-footer {
 	border-top: 1px solid var(--wp--preset--color--light-grey);
 	color: var(--wp--preset--color--dark-grey);

--- a/css/shared.css
+++ b/css/shared.css
@@ -87,3 +87,15 @@
 .wp-block-post-title  a:hover {
 	color: var(--wp--preset--color--red);
 }
+
+/* If there are a previous and next link, they will be placed left and right. */
+.wp-block-query-pagination {
+	display: flex;
+	justify-content: space-between;
+}
+
+/* If theres only a next link, place it right. */
+.wp-block-query-pagination-next {
+	text-align: right;
+	flex-grow: 1;
+}

--- a/experimental-theme.json
+++ b/experimental-theme.json
@@ -52,7 +52,9 @@
         "fontSize": "1rem",
         "lineHeight": "1.45"
       }
-    },
+    }
+  },
+  "blocks": {
     "core/site-title": {
       "typography": {
         "fontSize": "1.811rem",

--- a/experimental-theme.json
+++ b/experimental-theme.json
@@ -4,24 +4,29 @@
       "color": {
         "palette": [
           {
-            "slug": "black",
-            "color": "#222"
+            "color": "#222",
+            "name": "Black",
+            "slug": "black"
           },
           {
-            "slug": "white",
-            "color": "#fff"
+            "color": "#fff",
+            "name": "White",
+            "slug": "white"
           },
           {
-            "slug": "light-grey",
-            "color": "#ccc"
+            "color": "#ccc",
+            "name": "Light Grey",
+            "slug": "light-grey"
           },
           {
-            "slug": "dark-grey",
-            "color": "#757575"
+            "color": "#757575",
+            "name": "Dark Grey",
+            "slug": "dark-grey"
           },
           {
-            "slug": "red",
-            "color": "#c00"
+            "color": "#c00",
+            "name": "Red",
+            "slug": "red"
           }
         ],
         "link": true

--- a/functions.php
+++ b/functions.php
@@ -6,10 +6,24 @@
 function block_based_bosco_add_theme_supports() {
 	add_theme_support( 'automatic-feed-links' );
 	add_theme_support( 'post-thumbnails' );
+
+	add_theme_support( 'editor-styles' );
+	add_editor_style( [
+		'css/editor-style.css',
+		'css/shared.css',
+		block_based_bosco_font_url()
+	] );
 }
 add_action( 'after_setup_theme', 'block_based_bosco_add_theme_supports' );
 
 function block_based_bosco_enqueue_styles() {
+	wp_enqueue_style(
+		'block-based-bosco-shared-style',
+		get_stylesheet_directory_uri() . '/css/shared.css',
+		[],
+		wp_get_theme()->get( 'Version' )
+	);
+
 	wp_enqueue_style(
 		'block-based-bosco-style',
 		get_stylesheet_uri(),
@@ -20,7 +34,6 @@ function block_based_bosco_enqueue_styles() {
 	wp_enqueue_style( 'block-based-bosco-lora', block_based_bosco_font_url(), array(), null );
 }
 add_action( 'wp_enqueue_scripts', 'block_based_bosco_enqueue_styles' );
-add_action( 'enqueue_block_editor_assets', 'block_based_bosco_enqueue_styles' );
 
 /**
  * Remove some of the default Gutenberg block styles.

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,18 @@ Development for this theme is done on GitHub: https://github.com/WP-Development-
 
 == Changelog ==
 
+= 1.4 =
+
+* Release date: 26 July 2021
+* Tested with WordPress 5.8 and Gutenberg 11.1.0.
+* Update `theme.json` to align with the new naming and schema.
+* Add names to colors in the default palette.
+* Migrate `query-loop` to `post-template`.
+* Migrate Group block to current markup.
+* Refactor templates and styles to use the Layout controls.
+* Refactor stylesheets to account for iFramed editors.
+* Update credit link to point to theme page on WordPress.org.
+
 = 1.3 =
 
 * Release date: 25 February 2021

--- a/style.css
+++ b/style.css
@@ -432,27 +432,9 @@ img {
 Layout
  */
 
-/* These are the wrappers for all FSE blocks, the first on the frontend, the second in the Site Editor. */
-.wp-site-blocks,
-.editor-styles-wrapper .edit-site-block-editor__block-list {
-  max-width: calc(1px * var(--wp--custom--content--full-width));
-  margin-left: auto;
-  margin-right: auto;
-  border-bottom: 5px solid var(--wp--preset--color--red);
-  border-top: 5px solid var(--wp--preset--color--red);
-}
-
-/* Colors */
-
 /*
 Template Parts
  */
-
-/* Header */
-.site-header {
-  border-bottom: 1px solid var(--wp--preset--color--light-grey);
-  padding: 2.618em 0;
-}
 
 .editor-styles-wrapper h1.wp-block-site-title,
 .wp-block-site-title {
@@ -520,33 +502,9 @@ Template Parts
   border-top: 1px solid var(--wp--preset--color--light-grey);
 }
 
-/*
-Footer
- */
-
-.site-footer {
-  border-top: 1px solid var(--wp--preset--color--light-grey);
-  color: var(--wp--preset--color--dark-grey);
-  margin-top: 3.75rem;
-  padding: 1.159rem 1.618rem;
-}
-
-.site-footer .block-editor-block-list__block {
-  margin: 0;
-}
-
-.site-footer p {
-  margin: 0;
-}
-
 /*--------------------------------------------------------------
 Content
 --------------------------------------------------------------*/
-
-/* The wrapper for all posts and pages */
-.entry {
-  margin-top: 7.6875rem;
-}
 
 /* == Post Title ==== */
 
@@ -567,21 +525,8 @@ Content
   color: var(--wp--preset--color--red);
 }
 
-/* == Featured Image ==== */
-
-.entry-featured-image {
-  /* Use `calc()` to number convert to pixels. */
-  max-width: calc(1px * var(--wp--custom--content--wide-width));
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .wp-block-post-content.wp-block,
 .entry-content {
-  /* Use `calc()` to number convert to pixels. */
-  max-width: calc(1px * var(--wp--custom--content--normal-width));
-  margin-left: auto;
-  margin-right: auto;
   /* Fix aligned images from breaking out of the container */
   clear: both;
   overflow: hidden;
@@ -615,22 +560,6 @@ Content
   font-style: italic;
   font-weight: 400;
   margin: 0 0 1rem 0;
-}
-
-/* === Entry Footer == */
-
-.entry-footer {
-  border-top: 1px solid var(--wp--preset--color--light-grey);
-  color:  var(--wp--preset--color--dark-grey);
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 1.811rem;
-  max-width: calc(1px * var(--wp--custom--content--normal-width));
-  padding-top: 1.12rem;
-}
-
-.entry-footer.wp-block {
-  max-width: calc(1px * var(--wp--custom--content--normal-width));
 }
 
 /*

--- a/style.css
+++ b/style.css
@@ -490,25 +490,6 @@ Template Parts
 Content
 --------------------------------------------------------------*/
 
-/* == Post Title ==== */
-
-.wp-block-post-title {
-  /* Use `calc()` to number convert to pixels. */
-  max-width: calc(1px * var(--wp--custom--content--wide-width));
-  margin-bottom: 2.618rem;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.wp-block-post-title a {
-  color: var(--wp--preset--color--black);
-  text-decoration: none;
-}
-
-.wp-block-post-title  a:hover {
-  color: var(--wp--preset--color--red);
-}
-
 /* == Featured Content ==== */
 
 .entry-content h1 {

--- a/style.css
+++ b/style.css
@@ -633,44 +633,6 @@ Content
   max-width: calc(1px * var(--wp--custom--content--normal-width));
 }
 
-.entry-footer .wp-block-group__inner-container {
-  display: flex;
-}
-
-/* Gutenberg doesn't offer <span> tags, so the meta is in paragraphs. We need to override these styles */
-.editor-styles-wrapper .entry-footer p,
-.entry-footer p {
-  margin: 0;
-}
-
-/* Put a spacer between the "Posted on" text, and the post date. */
-.entry-footer .wp-block-post-date {
-  margin: 0 0 0 .3125rem;
-}
-
-/* Remove the extra space around the post author block */
-.editor-styles-wrapper .entry-footer .wp-block-post-author {
-  margin: 0;
-}
-
-/* The post author byline and name are wrapped in paragraph tags, but the design wants them on a single line. */
-.wp-block-post-author__content {
-  display: flex;
-}
-
-/* Add the dot separator before the post author. */
-.wp-block-post-author__content::before {
-  content: " \2022\ ";
-  margin-left: .5rem;
-  margin-right: .5rem;
-}
-
-/* Put a spacer between the "By" text, and the author name. */
-.editor-styles-wrapper p.wp-block-post-author__name,
-p.wp-block-post-author__name {
-  margin-left: .3125rem;
-}
-
 /*
 Templates
  */

--- a/style.css
+++ b/style.css
@@ -520,24 +520,6 @@ Content
   margin: 0 0 1rem 0;
 }
 
-/* == Archives === */
-.posts-navigation {
-  font-size: 1.159rem;
-  margin-top: 4.1875rem;
-}
-
-.posts-navigation .wp-block-group__inner-container {
-  display: flex;
-}
-
-.posts-navigation .wp-block-group__inner-container div {
-  flex-grow: 1;
-}
-
-.posts-navigation .wp-block-group__inner-container div:nth-child(2) {
-  text-align: right;
-}
-
 /*
 Comments - Adapted from existing Bosco theme.
  */

--- a/style.css
+++ b/style.css
@@ -1,9 +1,9 @@
 /*
 Theme Name: Block-Based Bosco
-Version: 1.3
+Version: 1.4
 Requires PHP: 7.0
-Requires at least: 5.6
-Tested up to: 5.6.2
+Requires at least: 5.8
+Tested up to: 5.8
 Description: Experimental Full Site Editing Theme
 Author: Frank Klein
 Author URI: https://wpdevelopment.courses/

--- a/style.css
+++ b/style.css
@@ -416,25 +416,6 @@ img {
   z-index: 100000;
 }
 
-/*
-Template Parts
- */
-
-.editor-styles-wrapper h1.wp-block-site-title,
-.wp-block-site-title {
-  margin: 0;
-}
-
-.wp-block-site-title a {
-  text-decoration: none;
-}
-
-.editor-styles-wrapper p.wp-block-site-tagline,
-.wp-block-site-tagline {
-  font-weight: bold;
-  margin: 0;
-}
-
 /*--------------------------------------------------------------
 Content
 --------------------------------------------------------------*/

--- a/style.css
+++ b/style.css
@@ -417,10 +417,6 @@ img {
 }
 
 /*
-Layout
- */
-
-/*
 Template Parts
  */
 
@@ -513,13 +509,6 @@ Content
   color: var(--wp--preset--color--red);
 }
 
-.wp-block-post-content.wp-block,
-.entry-content {
-  /* Fix aligned images from breaking out of the container */
-  clear: both;
-  overflow: hidden;
-}
-
 /* == Featured Content ==== */
 
 .entry-content h1 {
@@ -549,10 +538,6 @@ Content
   font-weight: 400;
   margin: 0 0 1rem 0;
 }
-
-/*
-Templates
- */
 
 /* == Archives === */
 .posts-navigation {

--- a/style.css
+++ b/style.css
@@ -435,57 +435,6 @@ Template Parts
   margin: 0;
 }
 
-/* == Navigation === */
-
-/* By default the navigation template part has a top and bottom border. */
-.wp-block-navigation {
-  border-top: 1px solid var(--wp--preset--color--light-grey);
-  border-bottom: 1px solid var(--wp--preset--color--light-grey);
-}
-
-/* If the navigation template part comes immediately after the header, we do not need the top border. */
-.site-header + .wp-block-navigation {
-  border-top: 0;
-}
-
-/* Generic styles */
-
-/* All links. */
-
-.wp-block-navigation-link__content {
-  color: var(--wp--preset--color--black);
-  font-weight: bold;
-  padding: 1.159rem 1.618rem;
-  text-decoration: none;
-  word-wrap: break-word;
-}
-
-.wp-block-navigation-link__content:hover {
-  color: var(--wp--preset--color--red);
-}
-
-/* First level */
-.wp-block-navigation > .wp-block-navigation__container > li {
-  margin: 0 0.89rem;
-}
-
-.wp-block-navigation > .wp-block-navigation__container > li > a {
-  text-transform: uppercase;
-}
-
-.wp-block-navigation-link__submenu-icon {
-  color: var(--wp--preset--color--light-grey);
-}
-
-/* Second level and more */
-.wp-block-navigation ul ul li:first-child {
-  border: none;
-}
-.wp-block-navigation ul ul li {
-  margin: 0;
-  border-top: 1px solid var(--wp--preset--color--light-grey);
-}
-
 /*--------------------------------------------------------------
 Content
 --------------------------------------------------------------*/

--- a/style.css
+++ b/style.css
@@ -379,18 +379,6 @@ img {
   max-width: 100%;
 }
 
-.aligncenter {
-  text-align: center;
-}
-
-.alignleft {
-  float: left;
-}
-
-.alignright {
-  float: right;
-}
-
 /* Screen Reader Text */
 .screen-reader-text {
   border: 0;

--- a/theme.json
+++ b/theme.json
@@ -30,6 +30,10 @@
         }
       ]
     },
+    "layout": {
+      "contentSize": "520px",
+      "wideWidth": "750px"
+    },
     "spacing": {
       "customPadding": true,
       "units": [ "rem" ]

--- a/theme.json
+++ b/theme.json
@@ -68,11 +68,24 @@
         "typography": {
           "fontSize": "1.811rem",
           "lineHeight": "1.3"
+        },
+        "spacing": {
+          "margin": {
+            "bottom": "0px",
+            "top": "0px"
+          }
         }
       },
       "core/site-tagline": {
         "typography": {
-          "fontSize": "1.618rem"
+          "fontSize": "1.618rem",
+          "fontWeight": "bold"
+        },
+        "spacing": {
+          "margin": {
+            "bottom": "0px",
+            "top": "0px"
+          }
         }
       },
       "core/heading/h2": {

--- a/theme.json
+++ b/theme.json
@@ -114,6 +114,16 @@
             "bottom": "2.618rem"
           }
         }
+      },
+      "core/query-pagination": {
+        "typography": {
+          "fontSize": "1.159rem"
+        },
+        "spacing": {
+          "margin": {
+            "top": "4.1875rem"
+          }
+        }
       }
     }
   }

--- a/theme.json
+++ b/theme.json
@@ -31,6 +31,10 @@
         ],
         "link": true
       },
+      "spacing": {
+        "customPadding": true,
+        "units": [ "rem" ]
+      },
       "custom": {
         "content": {
           "normalWidth": 520,

--- a/theme.json
+++ b/theme.json
@@ -105,9 +105,14 @@
           "lineHeight": "1.3"
         }
       },
-      "core/post-title/h2": {
+      "core/post-title": {
         "typography": {
           "fontSize": "2.4rem"
+        },
+        "spacing": {
+          "margin": {
+            "bottom": "2.618rem"
+          }
         }
       }
     }

--- a/theme.json
+++ b/theme.json
@@ -1,61 +1,63 @@
 {
+  "version": 1,
   "settings": {
-    "defaults": {
-      "color": {
-        "palette": [
-          {
-            "color": "#222",
-            "name": "Black",
-            "slug": "black"
-          },
-          {
-            "color": "#fff",
-            "name": "White",
-            "slug": "white"
-          },
-          {
-            "color": "#ccc",
-            "name": "Light Grey",
-            "slug": "light-grey"
-          },
-          {
-            "color": "#757575",
-            "name": "Dark Grey",
-            "slug": "dark-grey"
-          },
-          {
-            "color": "#c00",
-            "name": "Red",
-            "slug": "red"
-          }
-        ],
-        "link": true
-      },
-      "spacing": {
-        "customPadding": true,
-        "units": [ "rem" ]
-      },
-      "custom": {
-        "content": {
-          "normalWidth": 520,
-          "wideWidth": 750,
-          "fullWidth": 840
+    "color": {
+      "palette": [
+        {
+          "color": "#222",
+          "name": "Black",
+          "slug": "black"
+        },
+        {
+          "color": "#fff",
+          "name": "White",
+          "slug": "white"
+        },
+        {
+          "color": "#ccc",
+          "name": "Light Grey",
+          "slug": "light-grey"
+        },
+        {
+          "color": "#757575",
+          "name": "Dark Grey",
+          "slug": "dark-grey"
+        },
+        {
+          "color": "#c00",
+          "name": "Red",
+          "slug": "red"
         }
+      ]
+    },
+    "spacing": {
+      "customPadding": true,
+      "units": [ "rem" ]
+    },
+    "custom": {
+      "content": {
+        "normalWidth": 520,
+        "wideWidth": 750,
+        "fullWidth": 840
       }
     }
   },
   "styles": {
-    "root": {
-      "color": {
-        "background": "var(--wp--preset--color--white)",
-        "text": "var(--wp--preset--color--black)",
-        "link": "var(--wp--preset--color--red)"
-      },
-      "typography": {
-        "fontFamily": "Lora, Georgia, serif",
-        "fontSize": "1rem",
-        "lineHeight": "1.45"
+    "color": {
+      "background": "var(--wp--preset--color--white)",
+      "text": "var(--wp--preset--color--black)"
+    },
+    "elements": {
+      "link": {
+        "color": {
+          "text": "var(--wp--preset--color--red)"
+        }
       }
+    },
+    "typography": {
+      "fontFamily": "Lora, Georgia, serif",
+      "fontSize": "1rem",
+      "lineHeight": "1.45"
     }
   },
   "blocks": {

--- a/theme.json
+++ b/theme.json
@@ -51,6 +51,11 @@
       "background": "var(--wp--preset--color--white)",
       "text": "var(--wp--preset--color--black)"
     },
+    "typography": {
+      "fontFamily": "Lora, Georgia, serif",
+      "fontSize": "1rem",
+      "lineHeight": "1.45"
+    },
     "elements": {
       "link": {
         "color": {
@@ -58,57 +63,52 @@
         }
       }
     },
-    "typography": {
-      "fontFamily": "Lora, Georgia, serif",
-      "fontSize": "1rem",
-      "lineHeight": "1.45"
-    }
-  },
-  "blocks": {
-    "core/site-title": {
-      "typography": {
-        "fontSize": "1.811rem",
-        "lineHeight": "1.3"
-      }
-    },
-    "core/site-tagline": {
-      "typography": {
-        "fontSize": "1.618rem"
-      }
-    },
-    "core/heading/h2": {
-      "typography": {
-        "fontSize": "1.618rem",
-        "lineHeight": "1.3"
-      }
-    },
-    "core/heading/h3": {
-      "typography": {
-        "fontSize": "1.159rem",
-        "lineHeight": "1.3"
-      }
-    },
-    "core/heading/h4": {
-      "typography": {
-        "fontSize": "1rem",
-        "lineHeight": "1.3"
-      }
-    },
-    "core/heading/h5": {
-      "typography": {
-        "fontSize": "1rem",
-        "lineHeight": "1.3"
-      }
-    },
-    "core/heading/h6": {
-      "typography": {
-        "fontSize": "1rem",
-        "lineHeight": "1.3"
-      }
-    },
-    "core/post-title/h2": {
-      "typography": {
-        "fontSize": "2.4rem"
+    "blocks": {
+      "core/site-title": {
+        "typography": {
+          "fontSize": "1.811rem",
+          "lineHeight": "1.3"
+        }
+      },
+      "core/site-tagline": {
+        "typography": {
+          "fontSize": "1.618rem"
+        }
+      },
+      "core/heading/h2": {
+        "typography": {
+          "fontSize": "1.618rem",
+          "lineHeight": "1.3"
+        }
+      },
+      "core/heading/h3": {
+        "typography": {
+          "fontSize": "1.159rem",
+          "lineHeight": "1.3"
+        }
+      },
+      "core/heading/h4": {
+        "typography": {
+          "fontSize": "1rem",
+          "lineHeight": "1.3"
+        }
+      },
+      "core/heading/h5": {
+        "typography": {
+          "fontSize": "1rem",
+          "lineHeight": "1.3"
+        }
+      },
+      "core/heading/h6": {
+        "typography": {
+          "fontSize": "1rem",
+          "lineHeight": "1.3"
+        }
+      },
+      "core/post-title/h2": {
+        "typography": {
+          "fontSize": "2.4rem"
+        }
       }
     }
   }


### PR DESCRIPTION
* Tested with WordPress 5.8 and Gutenberg 11.1.0.
* Update `theme.json` to align with the new naming and schema.
* Add names to colors in the default palette.
* Migrate `query-loop` to `post-template`.
* Migrate Group block to current markup.
* Refactor templates and styles to use the Layout controls.
* Refactor stylesheets to account for iFramed editors.
* Update credit link to point to theme page on WordPress.org.